### PR TITLE
Unittest For B2C Payment Disbursement and B2C Payment Disbursement Reference modules 

### DIFF
--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/loan_disbursement.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/loan_disbursement.py
@@ -1,0 +1,23 @@
+import frappe
+
+from lending.loan_management.doctype.loan.loan import make_loan_disbursement
+
+def create_loan_disbursement(b2c_disbursement, b2c_disbursement_ref):
+    try:
+        loan = frappe.get_doc("Loan", b2c_disbursement_ref.reference_name)
+
+        disbursement_entry = make_loan_disbursement(
+            loan=loan.name,
+            company=loan.company,
+            applicant_type=loan.applicant_type,
+            applicant=loan.applicant,
+            pending_amount=b2c_disbursement_ref.allocated_amount
+        )
+
+        disbursement_entry.insert(ignore_permissions=True)
+        # disbursement_entry.submit()
+
+        frappe.db.commit()
+
+    except Exception as e:
+        frappe.log_error(frappe.get_traceback(), "Loan Disbursement Creation Failed")

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/mpsa_b2c.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/mpsa_b2c.py
@@ -170,7 +170,7 @@ def handle_successful_payment(b2c_disbursement, b2c_disbursement_ref):
         match b2c_disbursement_ref.reference_doctype:
             case "Salary Slip":
                 create_journal_entry(b2c_disbursement, b2c_disbursement_ref)
-            case "Employee Advance" | "Expense Claim" | "Purchase Invoice":
+            case "Employee Advance" | "Expense Claim" | "Purchase Invoice" | "Purchase Order":
                 create_payment_entry_for_doc(b2c_disbursement, b2c_disbursement_ref)
             case "Loan":
                 create_loan_disbursement(b2c_disbursement, b2c_disbursement_ref)
@@ -227,7 +227,6 @@ def create_mpesa_transaction_entry(result: dict, b2c_disbursement: Document, b2c
 
     except Exception as e:
         frappe.log_error(frappe.get_traceback(), "B2C Payment Transaction Save Failed")
-
 
 def create_journal_entry(b2c_disbursement, b2c_disbursement_ref):
     """ Create Journal Entry for Salary Slip after successful B2C payment."""

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/mpsa_b2c.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/mpsa_b2c.py
@@ -1,4 +1,5 @@
 import json
+import requests
 from datetime import datetime, timedelta
 from enum import Enum
 from urllib.parse import urlparse
@@ -68,6 +69,14 @@ class MpesaB2CConnector(MpesaConnector):
                     reference_doctype=doctype,
                     name=request_data.OriginatorConversationID,
                 )
+
+            except requests.Timeout as e:
+                update_integration_request(
+                    self.integration_request.name,
+                    status="Failed",
+                    error="Timeout: Remote server did not respond in time."
+                )
+
             except frappe.exceptions.DuplicateEntryError:
                 frappe.throw(
                     f"Integration Request with OriginatorConversationID {request_data.OriginatorConversationID} already exists."
@@ -182,7 +191,6 @@ def handle_successful_payment(b2c_disbursement, b2c_disbursement_ref):
     except Exception as e:
         error_msg = f"Error handling payment for {b2c_disbursement_ref.name}: {str(e)}"
         frappe.log_error(frappe.get_traceback(), "B2C Payment Disbursement Reference")
-
 
 def create_mpesa_transaction_entry(result: dict, b2c_disbursement: Document, b2c_disbursement_ref: Document):
     """

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/mpsa_b2c.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/mpsa_b2c.py
@@ -118,15 +118,17 @@ def results_callback_url(**kwargs) -> dict:
     """Handle the callback from MPesa API."""
     result = frappe._dict(kwargs["Result"])
     originator_conversation_id = result.get("OriginatorConversationID")
+    result_parameters = result.get("ResultParameters", {}).get("ResultParameter", [])
+    result_dict = {param["Key"]: param["Value"] for param in result_parameters}
     
     result_json = json.dumps(result)
 
     try:
-        b2c_payment_disburesement_reference = frappe.get_doc("B2C Payment Disbursement Reference", {"originator_conversation_id": originator_conversation_id})
-        b2c_payment_disburesement = frappe.get_doc(b2c_payment_disburesement_reference.parenttype, b2c_payment_disburesement_reference.parent)
+        b2c_payment_disbursement_reference = frappe.get_doc("B2C Payment Disbursement Reference", {"originator_conversation_id": originator_conversation_id})
+        b2c_payment_disbursement = frappe.get_doc(b2c_payment_disbursement_reference.parenttype, b2c_payment_disbursement_reference.parent)
 
         if result.get("ResultCode") != 0:
-            b2c_payment_disburesement_reference.payment_status = "Failed"
+            frappe.db.set_value("B2C Payment Disbursement Reference", b2c_payment_disbursement_reference, "payment_status", "Failed")
             
             update_integration_request(
                 originator_conversation_id,
@@ -136,13 +138,20 @@ def results_callback_url(**kwargs) -> dict:
             )
             frappe.log_error(f"B2C Request failed: {result.ResultDesc}", "Mpesa B2C Error")
 
-            publish_b2c_payment_update(b2c_payment_disburesement.name, b2c_payment_disburesement_reference.idx, b2c_payment_disburesement_reference.party, b2c_payment_disburesement_reference.allocated_amount, "Failed")
+            publish_b2c_payment_update(b2c_payment_disbursement.name, b2c_payment_disbursement_reference.idx, b2c_payment_disbursement_reference.party, b2c_payment_disbursement_reference.allocated_amount, "Failed")
 
         else:
-            create_mpesa_transaction_entry(result, b2c_payment_disburesement, b2c_payment_disburesement_reference)
+            create_mpesa_transaction_entry(result, b2c_payment_disbursement, b2c_payment_disbursement_reference)
 
-            b2c_payment_disburesement_reference.payment_status = "Paid"
-            b2c_payment_disburesement_reference.save(ignore_permissions=True)
+            frappe.db.set_value(
+                "B2C Payment Disbursement Reference", 
+                b2c_payment_disbursement_reference, 
+                {
+                    "reference_no": f"{result_dict.get("TransactionReceipt")}",
+                    "reference_date": f"{get_datetime(result_dict.get("TransactionCompletedDateTime"))}",
+                    "payment_status": "Paid"
+                }
+            )
             
             update_integration_request(
                 originator_conversation_id,
@@ -150,18 +159,15 @@ def results_callback_url(**kwargs) -> dict:
                 output=result_json,
             )
 
-            publish_b2c_payment_update(b2c_payment_disburesement.name, b2c_payment_disburesement_reference.idx, b2c_payment_disburesement_reference.party, b2c_payment_disburesement_reference.allocated_amount, "Paid")
+            publish_b2c_payment_update(b2c_payment_disbursement.name, b2c_payment_disbursement_reference.idx, b2c_payment_disbursement_reference.party, b2c_payment_disbursement_reference.allocated_amount, "Paid")
 
             frappe.enqueue(
                 "frappe_mpsa_payments.frappe_mpsa_payments.api.mpsa_b2c.handle_successful_payment",
                 queue="long",
                 timeout=600,
-                b2c_disbursement=b2c_payment_disburesement,
-                b2c_disbursement_ref=b2c_payment_disburesement_reference
+                b2c_disbursement=b2c_payment_disbursement,
+                b2c_disbursement_ref=b2c_payment_disbursement_reference
             )
-
-        b2c_payment_disburesement_reference.save(ignore_permissions=True)
-        frappe.db.commit()
 
     except Exception:
         frappe.log_error(frappe.get_traceback(), "Failed to update payment_status in callback")

--- a/frappe_mpsa_payments/frappe_mpsa_payments/api/mpsa_b2c.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/api/mpsa_b2c.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime, timedelta
 from enum import Enum
 from urllib.parse import urlparse
@@ -9,11 +10,11 @@ from frappe.model.document import Document
 from frappe.integrations.utils import create_request_log
 from frappe.utils import get_request_site_address, nowdate, get_datetime
 from frappe.utils.password import get_decrypted_password
-import json
-from ...utils.definitions import B2CRequestDefinition
-from ..connectors.connectors import MpesaConnector, update_integration_request
 
 from .payment_entry import create_payment_entry
+from .loan_disbursement import create_loan_disbursement
+from ...utils.definitions import B2CRequestDefinition
+from ..connectors.connectors import MpesaConnector, update_integration_request
 
 
 class URLS(Enum):
@@ -170,7 +171,9 @@ def handle_successful_payment(b2c_disbursement, b2c_disbursement_ref):
             case "Salary Slip":
                 create_journal_entry(b2c_disbursement, b2c_disbursement_ref)
             case "Employee Advance" | "Expense Claim" | "Purchase Invoice":
-                creat_payment_entry_for_doc(b2c_disbursement, b2c_disbursement_ref)
+                create_payment_entry_for_doc(b2c_disbursement, b2c_disbursement_ref)
+            case "Loan":
+                create_loan_disbursement(b2c_disbursement, b2c_disbursement_ref)
             case _:
                 frappe.log_error(
                     f"Unsupported reference_doctype: {b2c_disbursement_ref.reference_doctype}",
@@ -262,9 +265,7 @@ def create_journal_entry(b2c_disbursement, b2c_disbursement_ref):
     except Exception as e:
         frappe.log_error(frappe.get_traceback(), "Failed to create Journal Entry")
 
-        
-
-def creat_payment_entry_for_doc(b2c_disbursement, b2c_disbursement_ref):
+def create_payment_entry_for_doc(b2c_disbursement, b2c_disbursement_ref):
     party_type = b2c_disbursement_ref.party_type
     party_account = b2c_disbursement.paid_to
     party = frappe.db.get_value(party_type, b2c_disbursement_ref.party, "name")

--- a/frappe_mpsa_payments/frappe_mpsa_payments/connectors/connectors.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/connectors/connectors.py
@@ -62,6 +62,7 @@ class BaseMpesaConnector:
 class MpesaConnector(BaseMpesaConnector):
     
     def __init__(self, settings_name: str):
+        super().__init__()
         self.settings_name = settings_name
         self._endpoint: str | None = None
         self._payload: dict | None = None
@@ -72,6 +73,7 @@ class MpesaConnector(BaseMpesaConnector):
         self._custom_headers: dict = {}
         self._base_url: str | None = None
         self._url: str | None = None
+        self._timeout: int = 30
         self.integration_request = None
         self.doctype = self.document_name = self.error = None
 
@@ -104,6 +106,11 @@ class MpesaConnector(BaseMpesaConnector):
         frappe.db.set_value("Mpesa Settings", self.settings_name, "expires_in", int(expires_in))
         frappe.db.set_value("Mpesa Settings", self.settings_name, "token_expiry", token_expiry)
         frappe.db.commit()
+
+
+    def _set_timeout(self, seconds: int):
+        self._timeout = seconds
+        return self
 
 
     def authenticate(self) -> str:
@@ -192,10 +199,10 @@ class MpesaConnector(BaseMpesaConnector):
     def _send_request(self) -> requests.Response:
         headers = self._get_authenticated_headers()
         method_map = {
-            "GET": lambda: requests.get(self._url, headers=headers, params=self._payload),
-            "POST": lambda: requests.post(self._url, json=self._payload, headers=headers),
-            "PATCH": lambda: requests.patch(self._url, json=self._payload, headers=headers),
-            "PUT": lambda: requests.put(self._url, json=self._payload, headers=headers),
+            "GET": lambda: requests.get(self._url, headers=headers, params=self._payload, timeout=self._timeout),
+            "POST": lambda: requests.post(self._url, json=self._payload, headers=headers, timeout=self._timeout),
+            "PATCH": lambda: requests.patch(self._url, json=self._payload, headers=headers, timeout=self._timeout),
+            "PUT": lambda: requests.put(self._url, json=self._payload, headers=headers, timeout=self._timeout),
         }
 
         if self._method in {"PATCH", "PUT"} and self._payload and "id" in self._payload:

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.js
@@ -326,13 +326,13 @@ frappe.ui.form.on("B2C Payment Disbursement", {
       if (frm.doc.paid_amount) {
         frm.set_value("base_paid_amount", flt(frm.doc.paid_amount) * flt(frm.doc.source_exchange_rate));
         frm.events.calculate_paid_amount_kes(frm);
-        // frm.events.allocate_party_amount_against_ref_docs(frm, frm.doc.paid_amount);
+        frm.events.allocate_party_amount_against_ref_docs(frm, frm.doc.paid_amount);
       }
       frm.set_df_property("source_exchange_rate", "read_only", erpnext.stale_rate_allowed() ? 0 : 1);
     },
 
     target_exchange_rate: function (frm) {
-      // frm.events.allocate_party_amount_against_ref_docs(frm, frm.doc.paid_amount);
+      frm.events.allocate_party_amount_against_ref_docs(frm, frm.doc.paid_amount);
       frm.set_df_property("source_exchange_rate", "read_only", erpnext.stale_rate_allowed() ? 0 : 1);
     },
 
@@ -341,7 +341,7 @@ frappe.ui.form.on("B2C Payment Disbursement", {
         frm.set_value("base_paid_amount", flt(frm.doc.paid_amount) * flt(frm.doc.source_exchange_rate));
       }
       frm.events.calculate_paid_amount_kes(frm);
-      // frm.events.allocate_party_amount_against_ref_docs(frm, frm.doc.paid_amount);
+      frm.events.allocate_party_amount_against_ref_docs(frm, frm.doc.paid_amount);
     },
 
     calculate_paid_amount_kes: function (frm) {
@@ -483,11 +483,15 @@ frappe.ui.form.on("B2C Payment Disbursement", {
         callback: function (r) {
           if (r.message) {
             frm.refresh_field("references");
-            frappe.msgprint({
-              message: __("References populated successfully"),
-              title: __("Success"),
-              indicator: "green"
-            })
+            if (frappe.flags.allocate_payment_amount) {
+              frm.events.allocate_party_amount_against_ref_docs(frm, frm.doc.paid_amount);
+            } else {
+              frappe.msgprint({
+                message: __("References populated successfully"),
+                title: __("Success"),
+                indicator: "green"
+              })
+            }
           }
         },
       });
@@ -527,6 +531,36 @@ frappe.ui.form.on("B2C Payment Disbursement", {
         },
       });
     },
+    allocate_party_amount_against_ref_docs: function(frm, paid_amount) {
+      if (!frm.doc.references || !frm.doc.references.length) {
+          return;
+      }
+
+      frappe.call({
+          method: "allocate_amount_to_references",
+          doc: frm.doc,
+          args: {
+              paid_amount: paid_amount || frm.doc.paid_amount,
+              paid_amount_change: 1,
+              allocate_payment_amount: frappe.flags.allocate_payment_amount || 1
+          },
+          callback: function(r) {
+              frm.refresh_field("references");
+              frappe.msgprint({
+                  message: __("References populated and allocated successfully"),
+                  title: __("Success"),
+                  indicator: "green"
+              });
+          },
+          error: function(r) {
+              frappe.msgprint({
+                  message: __("Error allocating amounts: " + r.message),
+                  title: __("Error"),
+                  indicator: "red"
+              });
+          }
+      });
+    }
   });
 
 function generateUUIDv4() {

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.js
@@ -96,7 +96,7 @@ frappe.ui.form.on("B2C Payment Disbursement", {
 
       frm.set_query("transaction_to_pay_against", function () {
         const doctypes = frm.doc.party_type === "Employee"
-              ? ["Salary Slip", "Employee Advance", "Expense Claim"]
+              ? ["Salary Slip", "Employee Advance", "Expense Claim", "Loan"]
               : ["Purchase Invoice", "Purchase Order"];
         return {
           filters: { name: ["in", doctypes] },
@@ -106,7 +106,7 @@ frappe.ui.form.on("B2C Payment Disbursement", {
       frm.set_query("reference_doctype", "references", function () {
         let doctypes = [];
         if (frm.doc.party_type == "Employee") {
-          doctypes = ["Employee Advance", "Expense Claim", "Salary Slip"];
+          doctypes = ["Employee Advance", "Expense Claim", "Salary Slip", "Loan"];
         } else if (frm.doc.party_type == "Supplier") {
           doctypes = ["Purchase Invoice", "Purchase Order"];
         }

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.js
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.js
@@ -375,7 +375,34 @@ frappe.ui.form.on("B2C Payment Disbursement", {
           label: __("Party"),
           fieldname: "party",
           options: frm.doc.party_type,
-          
+          get_query: () => {
+            const party_type = frm.doc.party_type;
+            let filters = {};
+
+            if (party_type === "Employee") {
+              filters.status = "Active";
+            } else if (party_type === "Supplier") {
+              filters.disabled = 0;
+            }
+
+            return { filters };
+          }
+        },
+        { fieldtype: "Column Break" },
+        {
+          fieldtype: "Link",
+          label: __("Payroll Entry"),
+          fieldname: "payroll_entry",
+          options: "Payroll Entry",
+          hidden: 1,
+          depends_on: () => frm.doc.transaction_to_pay_against === "Salary Slip",
+          get_query: () => {
+            return {
+              filters: {
+                docstatus: 1
+              }
+            };
+          }
         },
         { fieldtype: "Section Break", label: __("Posting Date") },
         {
@@ -430,28 +457,28 @@ frappe.ui.form.on("B2C Payment Disbursement", {
     },
 
     validate_filters_data: function (frm, filters) {
-      // const fields = {
-      //   "Posting Date": ["from_posting_date", "to_posting_date"],
-      //   // "Due Date": ["from_due_date", "to_due_date"],
-      //   // "Advance Amount": ["from_posting_date", "to_posting_date"],
-      // };
+      const fields = {
+        "Posting Date": ["from_posting_date", "to_posting_date"],
+        "Due Date": ["from_due_date", "to_due_date"],
+        "Outstanding Amount": ["outstanding_amt_greater_than", "outstanding_amt_less_than"]
+      };
 
-      // for (let key in fields) {
-      //   let from_field = fields[key][0];
-      //   let to_field = fields[key][1];
+      for (let key in fields) {
+        let from_field = fields[key][0];
+        let to_field = fields[key][1];
 
-      //   if (filters[from_field] && !filters[to_field]) {
-      //     frappe.throw(__("Error: {0} is mandatory field", [to_field.replace(/_/g, " ")]));
-      //   } else if (filters[from_field] && filters[from_field] > filters[to_field]) {
-      //     frappe.throw(
-      //       __("{0}: {1} must be less than {2}", [
-      //         key,
-      //         from_field.replace(/_/g, " "),
-      //         to_field.replace(/_/g, " "),
-      //       ])
-      //     );
-      //   }
-      // }
+        if (filters[from_field] && !filters[to_field]) {
+          frappe.throw(__("Error: {0} is mandatory field", [to_field.replace(/_/g, " ")]));
+        } else if (filters[from_field] && filters[from_field] > filters[to_field]) {
+          frappe.throw(
+            __("{0}: {1} must be less than {2}", [
+              key,
+              from_field.replace(/_/g, " "),
+              to_field.replace(/_/g, " "),
+            ])
+          );
+        }
+      }
     },
 
     get_outstanding_documents: function (frm, filters) {

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.py
@@ -52,28 +52,6 @@ class B2CPaymentDisbursement(Document):
                 indicator="red" if any_errors else "green"
             )
 
-        self.on_update()
-        self.db_set("status", self.status)
-
-    def on_update(self) -> None:
-        """Update overall status based on payment references"""
-        if not self.references:
-            self.status = "Not Initiated"
-            return
-        
-        statuses = [ref.payment_status for ref in self.references]
-
-        if all(status == "Paid" for status in statuses):
-            self.status = "Paid"
-        elif all(status == "Failed" for status in statuses):
-            self.status = "Failed"
-        elif all(status == "Not Initiated" for status in statuses):
-            self.status = "Not Initiated"
-        elif any(status == "Paid" for status in statuses):
-            self.status = "Partially Paid"
-        else:
-            self.status = "Not Initiated"
-
     def validate_mandatory_fields(self) -> None:
         mandatory_fields = ["company", "posting_date", "party_type", "paid_from", "paid_to"]
         for field in mandatory_fields:
@@ -229,8 +207,6 @@ class B2CPaymentDisbursement(Document):
                 indicator="red" if any_errors else "green"
             )
 
-        self.on_update()
-        self.db_set("status", self.status)
 
     @frappe.whitelist()
     def get_outstanding_reference_documents(self, args: Dict) -> List[Dict]:

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.py
@@ -530,3 +530,46 @@ class B2CPaymentDisbursement(Document):
             return contact[0].get("phone") or contact[0].get("mobile_no") or "" if contact else ""
         
         return ""
+
+    @frappe.whitelist()
+    def allocate_amount_to_references(self, paid_amount, paid_amount_change=0, allocate_payment_amount=None):
+        if not self.references:
+            return
+
+        allocate_payment_amount = allocate_payment_amount if allocate_payment_amount is not None else frappe.flags.allocate_payment_amount or False
+
+        if not allocate_payment_amount:
+            for ref in self.references:
+                ref.allocated_amount = 0
+            return
+        
+        precision = self.precision("paid_amount")
+        total_positive_outstanding = 0
+        total_negative_outstanding = 0
+        paid_amount = flt(paid_amount, precision)
+
+        for ref in self.references:
+            outstanding_amount = flt(ref.outstanding_amount, precision)
+            if outstanding_amount > 0:
+                total_positive_outstanding += outstanding_amount
+            else:
+                total_negative_outstanding -= abs(outstanding_amount)
+
+        allocated_positive_outstanding = 0
+        allocated_negative_outstanding = 0
+
+        if total_positive_outstanding > paid_amount:
+            remaining_outstanding = flt(total_positive_outstanding - paid_amount, precision)
+            allocated_negative_outstanding = min(remaining_outstanding, total_negative_outstanding)
+        allocated_positive_outstanding = paid_amount + allocated_negative_outstanding
+
+        for ref in self.references:
+            outstanding_amount = flt(ref.outstanding_amount, precision)
+            if outstanding_amount > 0 and allocated_positive_outstanding >= 0:
+                ref.allocated_amount = min(allocated_positive_outstanding, outstanding_amount)
+                allocated_positive_outstanding = flt(allocated_positive_outstanding - ref.allocated_amount, precision)
+            elif outstanding_amount < 0 and allocated_negative_outstanding > 0:
+                ref.allocated_amount = min(allocated_negative_outstanding, abs(outstanding_amount)) * -1
+                allocated_negative_outstanding = flt(allocated_negative_outstanding - abs(ref.allocated_amount), precision)
+            else:
+                ref.allocated_amount = 0

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/b2c_payment_disbursement.py
@@ -274,8 +274,11 @@ class B2CPaymentDisbursement(Document):
             **config.additional_filters
         }
 
+        doctype = args.get("transaction_to_pay_against")
+        party_field = "applicant" if doctype == "Loan" else "employee"
+
         if args.get("party"):
-            filters["employee"] = args["party"]
+            filters[party_field] = args["party"]
         
         self._add_date_filter(filters, config.date_field, args.get("from_posting_date"), args.get("to_posting_date"))
 
@@ -354,6 +357,9 @@ class B2CPaymentDisbursement(Document):
             )
     
         return entries
+
+    def _fetch_unpaid_salary_slips(self, doctype: str, args: Dict, filters: Dict) -> List[Dict]:
+        pass
 
     def _fetch_erpnext_entries(self, doctype: str, args: Dict) -> List[Dict]:
         """
@@ -481,9 +487,14 @@ class B2CPaymentDisbursement(Document):
 
     def _extract_party_info(self, entry: Dict, args: Dict) -> Optional[Dict]:
         """Extract party and party_type from entry or args."""
+        doctype = args.get("transaction_to_pay_against")
 
-        party = entry.get("party") or entry.get("employee") or entry.get("supplier")
-        party_type = entry.get("party_type") or args.get("party_type")
+        if doctype == "Loan":
+            party = entry.get("applicant")
+            party_type = entry.get("applicant_type")
+        else:
+            party = entry.get("party") or entry.get("employee") or entry.get("supplier")
+            party_type = entry.get("party_type") or args.get("party_type")
         
         if not party or not party_type:
             app_logger.info(f"Skipping entry due to missing party or party_type: {entry}")

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/config.py
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement/config.py
@@ -50,5 +50,12 @@ DOCTYPE_CONFIGS = {
         additional_filters={},
         payable_amount_calc=lambda e: e.get("base_rounded_total") or e.get("rounded_total") or e.get("outstanding_amount") or 0,
         invoice_amount_field="net_pay"
+    ),
+    "Loan": DoctypeConfig(
+        fields=["name", "applicant_type", "applicant", "loan_amount", "disbursed_amount"],
+        date_field="posting_date",
+        additional_filters={"status": ["in", ["Sanctioned", "Partially Disbursed"]]},
+        payable_amount_calc=lambda e: (e.loan_amount or 0) - (e.disbursed_amount or 0),
+        invoice_amount_field="loan_amount"
     )
 }

--- a/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement_reference/b2c_payment_disbursement_reference.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/doctype/b2c_payment_disbursement_reference/b2c_payment_disbursement_reference.json
@@ -130,7 +130,7 @@
   },
   {
    "fieldname": "reference_date",
-   "fieldtype": "Date",
+   "fieldtype": "Datetime",
    "label": "Cheque/Reference Date"
   },
   {
@@ -160,7 +160,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2025-05-17 09:15:21.803090",
+ "modified": "2025-05-29 19:36:51.020235",
  "modified_by": "Administrator",
  "module": "Frappe Mpsa Payments",
  "name": "B2C Payment Disbursement Reference",

--- a/frappe_mpsa_payments/frappe_mpsa_payments/workspace/mpesa/mpesa.json
+++ b/frappe_mpsa_payments/frappe_mpsa_payments/workspace/mpesa/mpesa.json
@@ -1,180 +1,199 @@
 {
-  "charts": [],
-  "content": "[{\"id\":\"nu2bkf51Ir\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h3\\\">Mpesa</span>\",\"col\":12}},{\"id\":\"v5xMov9fuY\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"IitgNsFwsJ\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Shortcuts</span>\",\"col\":12}},{\"id\":\"gvenJof67-\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Mpesa Settings\",\"col\":3}},{\"id\":\"0da8pdMCsQ\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Integration Request\",\"col\":3}},{\"id\":\"UdyOBPCeG1\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Error Log\",\"col\":3}},{\"id\":\"dee9XfjZYm\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Mpesa Payment Reconciliation\",\"col\":3}},{\"id\":\"AgIlCNBsXy\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"Bl25BRZWzc\",\"type\":\"card\",\"data\":{\"card_name\":\"Configuration\",\"col\":3}},{\"id\":\"Eqauc23rby\",\"type\":\"card\",\"data\":{\"card_name\":\"Payments\",\"col\":4}}]",
-  "creation": "2025-03-06 09:26:13.194859",
-  "custom_blocks": [],
-  "docstatus": 0,
-  "doctype": "Workspace",
-  "for_user": "",
-  "hide_custom": 0,
-  "icon": "money-coins-1",
-  "idx": 0,
-  "indicator_color": "green",
-  "is_hidden": 0,
-  "label": "Mpesa",
-  "links": [
-    {
-      "hidden": 0,
-      "is_query_report": 0,
-      "label": "Configuration",
-      "link_count": 5,
-      "link_type": "DocType",
-      "onboard": 0,
-      "type": "Card Break"
-    },
-    {
-      "hidden": 0,
-      "is_query_report": 0,
-      "label": "Mpesa Settings",
-      "link_count": 0,
-      "link_to": "Mpesa Settings",
-      "link_type": "DocType",
-      "onboard": 0,
-      "type": "Link"
-    },
-    {
-      "hidden": 0,
-      "is_query_report": 0,
-      "label": "Mpesa Public Key Certificate",
-      "link_count": 0,
-      "link_to": "Mpesa Public Key Certificate",
-      "link_type": "DocType",
-      "onboard": 0,
-      "type": "Link"
-    },
-    {
-      "hidden": 0,
-      "is_query_report": 0,
-      "label": "Mpesa C2B Register URL",
-      "link_count": 0,
-      "link_to": "Mpesa C2B Payment Register URL",
-      "link_type": "DocType",
-      "onboard": 0,
-      "type": "Link"
-    },
-    {
-      "hidden": 0,
-      "is_query_report": 0,
-      "label": "Payment Gateway",
-      "link_count": 0,
-      "link_to": "Payment Gateway",
-      "link_type": "DocType",
-      "onboard": 0,
-      "type": "Link"
-    },
-    {
-      "hidden": 0,
-      "is_query_report": 0,
-      "label": "Payment Gateway Account",
-      "link_count": 0,
-      "link_to": "Payment Gateway Account",
-      "link_type": "DocType",
-      "onboard": 0,
-      "type": "Link"
-    },
-    {
-      "hidden": 0,
-      "is_query_report": 0,
-      "label": "Payments",
-      "link_count": 5,
-      "link_type": "DocType",
-      "onboard": 0,
-      "type": "Card Break"
-    },
-    {
-      "hidden": 0,
-      "is_query_report": 0,
-      "label": "Mpesa C2B Payment Register",
-      "link_count": 0,
-      "link_to": "Mpesa C2B Payment Register",
-      "link_type": "DocType",
-      "onboard": 0,
-      "type": "Link"
-    },
-    {
-      "hidden": 0,
-      "is_query_report": 0,
-      "label": "Mpesa Express Request",
-      "link_count": 0,
-      "link_to": "Mpesa Express Request",
-      "link_type": "DocType",
-      "onboard": 0,
-      "type": "Link"
-    },
-    {
-      "hidden": 0,
-      "is_query_report": 0,
-      "label": "Mpesa Payment Reconciliation",
-      "link_count": 0,
-      "link_to": "Mpesa Payment Reconciliation",
-      "link_type": "DocType",
-      "onboard": 0,
-      "type": "Link"
-    },
-    {
-      "hidden": 0,
-      "is_query_report": 0,
-      "label": "Payment Entry",
-      "link_count": 0,
-      "link_to": "Payment Entry",
-      "link_type": "DocType",
-      "onboard": 0,
-      "type": "Link"
-    },
-    {
-      "hidden": 0,
-      "is_query_report": 0,
-      "label": "Payment Request",
-      "link_count": 0,
-      "link_to": "Payment Request",
-      "link_type": "DocType",
-      "onboard": 0,
-      "type": "Link"
-    }
-  ],
-  "modified": "2025-03-26 09:29:13.383811",
-  "modified_by": "Administrator",
-  "module": "Frappe Mpsa Payments",
-  "name": "Mpesa",
-  "number_cards": [],
-  "owner": "mwendwa@navari.co.ke",
-  "parent_page": "",
-  "public": 1,
-  "quick_lists": [],
-  "roles": [],
-  "sequence_id": 48.0,
-  "shortcuts": [
-    {
-      "color": "Grey",
-      "doc_view": "List",
-      "label": "Mpesa Settings",
-      "link_to": "Mpesa Settings",
-      "stats_filter": "[]",
-      "type": "DocType"
-    },
-    {
-      "color": "Green",
-      "doc_view": "List",
-      "label": "Integration Request",
-      "link_to": "Integration Request",
-      "stats_filter": "[]",
-      "type": "DocType"
-    },
-    {
-      "color": "Red",
-      "doc_view": "List",
-      "label": "Error Log",
-      "link_to": "Error Log",
-      "stats_filter": "[]",
-      "type": "DocType"
-    },
-    {
-      "color": "Grey",
-      "doc_view": "List",
-      "label": "Mpesa Payment Reconciliation",
-      "link_to": "Mpesa Payment Reconciliation",
-      "type": "DocType"
-    }
-  ],
-  "title": "Mpesa"
+ "charts": [],
+ "content": "[{\"id\":\"nu2bkf51Ir\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h3\\\">Mpesa</span>\",\"col\":12}},{\"id\":\"v5xMov9fuY\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"IitgNsFwsJ\",\"type\":\"header\",\"data\":{\"text\":\"<span class=\\\"h4\\\">Shortcuts</span>\",\"col\":12}},{\"id\":\"gvenJof67-\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Mpesa Settings\",\"col\":3}},{\"id\":\"0da8pdMCsQ\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Integration Request\",\"col\":3}},{\"id\":\"UdyOBPCeG1\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Error Log\",\"col\":3}},{\"id\":\"dee9XfjZYm\",\"type\":\"shortcut\",\"data\":{\"shortcut_name\":\"Mpesa Payment Reconciliation\",\"col\":3}},{\"id\":\"AgIlCNBsXy\",\"type\":\"spacer\",\"data\":{\"col\":12}},{\"id\":\"Bl25BRZWzc\",\"type\":\"card\",\"data\":{\"card_name\":\"Configuration\",\"col\":4}},{\"id\":\"Eqauc23rby\",\"type\":\"card\",\"data\":{\"card_name\":\"Payments\",\"col\":4}},{\"id\":\"U7swFux4jx\",\"type\":\"card\",\"data\":{\"card_name\":\"Disbursements\",\"col\":4}},{\"id\":\"LIITib9evX\",\"type\":\"paragraph\",\"data\":{\"text\":\"Reports\",\"col\":12}}]",
+ "creation": "2025-03-06 09:26:13.194859",
+ "custom_blocks": [],
+ "docstatus": 0,
+ "doctype": "Workspace",
+ "for_user": "",
+ "hide_custom": 0,
+ "icon": "money-coins-1",
+ "idx": 0,
+ "indicator_color": "green",
+ "is_hidden": 0,
+ "label": "Mpesa",
+ "links": [
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Configuration",
+   "link_count": 5,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Mpesa Settings",
+   "link_count": 0,
+   "link_to": "Mpesa Settings",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Mpesa Public Key Certificate",
+   "link_count": 0,
+   "link_to": "Mpesa Public Key Certificate",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Mpesa C2B Register URL",
+   "link_count": 0,
+   "link_to": "Mpesa C2B Payment Register URL",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Payment Gateway",
+   "link_count": 0,
+   "link_to": "Payment Gateway",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Payment Gateway Account",
+   "link_count": 0,
+   "link_to": "Payment Gateway Account",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Payments",
+   "link_count": 5,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Mpesa C2B Payment Register",
+   "link_count": 0,
+   "link_to": "Mpesa C2B Payment Register",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Mpesa Express Request",
+   "link_count": 0,
+   "link_to": "Mpesa Express Request",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Mpesa Payment Reconciliation",
+   "link_count": 0,
+   "link_to": "Mpesa Payment Reconciliation",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Payment Entry",
+   "link_count": 0,
+   "link_to": "Payment Entry",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Payment Request",
+   "link_count": 0,
+   "link_to": "Payment Request",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "Disbursements",
+   "link_count": 1,
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Card Break"
+  },
+  {
+   "hidden": 0,
+   "is_query_report": 0,
+   "label": "B2C Payment Disbursement",
+   "link_count": 0,
+   "link_to": "B2C Payment Disbursement",
+   "link_type": "DocType",
+   "onboard": 0,
+   "type": "Link"
+  }
+ ],
+ "modified": "2025-05-27 14:32:50.074433",
+ "modified_by": "Administrator",
+ "module": "Frappe Mpsa Payments",
+ "name": "Mpesa",
+ "number_cards": [],
+ "owner": "mwendwa@navari.co.ke",
+ "parent_page": "",
+ "public": 1,
+ "quick_lists": [],
+ "roles": [],
+ "sequence_id": 48.0,
+ "shortcuts": [
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Mpesa Settings",
+   "link_to": "Mpesa Settings",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Green",
+   "doc_view": "List",
+   "label": "Integration Request",
+   "link_to": "Integration Request",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Red",
+   "doc_view": "List",
+   "label": "Error Log",
+   "link_to": "Error Log",
+   "stats_filter": "[]",
+   "type": "DocType"
+  },
+  {
+   "color": "Grey",
+   "doc_view": "List",
+   "label": "Mpesa Payment Reconciliation",
+   "link_to": "Mpesa Payment Reconciliation",
+   "type": "DocType"
+  }
+ ],
+ "title": "Mpesa"
 }


### PR DESCRIPTION
This PR introduces a full suite of unit tests for the B2CPaymentDisbursement and MPesaB2CEmployeePaymentItem doctypes. It ensures correctness and reliability across core validation, utility logic, and setter methods.

###  Added Tests

#### Mandatory Field Validation
- `validate_mandatory_fields` – Ensures errors are raised for missing required fields and empty references.
- `validate_mode_of_payment` – Verifies the mode of payment is present and valid.

#### Party Type & Mode of Payment
- Validates both correct and incorrect values for `party_type`.
- Ensures Mpesa setting is only set when `payment_type` is `"Mpesa Disbursement"`.

####  Amount Validation
- Tests edge cases for `paid_amount` being zero, negative, or mismatched against allocations.
- Confirms `base_paid_amount` is required when the currency is not KES.

####  Reference Doctype Matching
- Verifies that parent and child reference doctypes match.
- Asserts that mismatches correctly raise `ValidationError`.

#### UUID Generation
- Ensures a UUID is generated using the `_generate_uuid_v4()` method.
- Checks that the UUID has the expected length and format.

#### Phone Number Validation
- Tests `sanitise_phone_number()` for valid and invalid input formats.
- Validates `is_valid_receiver_contact()` correctly identifies invalid contacts.

####  Currency Handling
- Tests `set_missing_values` method for:
  - Setting `company_currency` only if not already present.
  - Setting `source_exchange_rate` by mocking `get_cached_value`.

